### PR TITLE
GRUND-476 remove logo but added a sort of label

### DIFF
--- a/web/themes/grundsalg/templates/layout/itkore-footer-block.html.twig
+++ b/web/themes/grundsalg/templates/layout/itkore-footer-block.html.twig
@@ -16,7 +16,8 @@
         <div class="footer--col-inner">
           <h3 class="footer--title">Kontakt</h3>
           {{ contact_text }}
-          <div class="footer--logo">
+          <p class="visually-hidden focusable">Aarhus Kommune</p>
+          <div class="footer--logo" aria-hidden="true">
             {% include '@grundsalg/../icons/aarhus-logo.svg' %}
           </div>
         </div>


### PR DESCRIPTION
Så vidt jeg har forstået skal logoet fjernes for skærmlæsere, men de nævnte at afsenderen (Aarhus Kommune), stadig skal være synlig på siden, så nu har de fået en label i stedet.